### PR TITLE
feat: lock screen video wallpaper via Apple Aerial injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ LiveWallpaper.icon/icon.json
 LiveWallpaper.icon/Assets/roller 2.svg
 /LiveWallpaper.icon
 /AppIcon.icon
+
+.cursor/

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -991,6 +991,7 @@ class WallpaperViewModel: ObservableObject {
             let videoPath = rawPath
             if manager.isSystemSlotInstalled {
                 manager.updateUserSymlink(videoPath)
+                manager.writeIndexPlist(nil)
                 defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
                 lockScreenVideoEnabled = true
                 lockScreenVideoError = nil
@@ -1002,6 +1003,7 @@ class WallpaperViewModel: ObservableObject {
                             self.lockScreenVideoError = error.localizedDescription
                             self.lockScreenVideoEnabled = false
                         } else {
+                            manager.writeIndexPlist(nil)
                             self.defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
                             self.lockScreenVideoEnabled = true
                             self.lockScreenVideoError = nil

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -138,6 +138,8 @@ enum L {
         "Vignette bar (Reapply the wallpaper after change)", comment: "")
 
     static let rotationDelay = NSLocalizedString("Wallpaper rotation delay", comment: "")
+    static let lockScreenVideo = NSLocalizedString("lock_screen_video", comment: "")
+    static let lockScreenVideoSubtitle = NSLocalizedString("lock_screen_video_subtitle", comment: "")
 }
 
 // MARK: - UserDefaults Keys
@@ -154,6 +156,7 @@ enum UserDefaultsKeys {
     static let rotation = "rotation"
     static let rdelay = "rdelay"
     static let rtype = "rtype"
+    static let lockScreenVideo = "lockscreenVideoEnabled"
 
 }
 
@@ -782,6 +785,31 @@ struct SettingsView: View {
                             viewModel.resetUserData()
                         }
                     }
+
+                    Divider()
+
+                    // Lock Screen Video
+                    VStack(alignment: .leading, spacing: 4) {
+                        SettingRow(title: L.lockScreenVideo) {
+                            Toggle("", isOn: Binding(
+                                get: { viewModel.lockScreenVideoEnabled },
+                                set: { viewModel.setLockScreenVideo($0) }
+                            ))
+                            .toggleStyle(.switch)
+                        }
+                        if let subtitle = Optional(L.lockScreenVideoSubtitle), !viewModel.lockScreenVideoEnabled {
+                            Text(subtitle)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.leading, 8)
+                        }
+                        if let error = viewModel.lockScreenVideoError {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .padding(.leading, 8)
+                        }
+                    }
                 }
                 .padding()
             }
@@ -924,6 +952,8 @@ class WallpaperViewModel: ObservableObject {
     @Published var pauseOnAppFocus: Bool = true
     @Published var volume: Double = 50.0
     @Published var vinttageBar: Bool = true
+    @Published var lockScreenVideoEnabled: Bool = false
+    @Published var lockScreenVideoError: String? = nil
 
     private var currentReloadID = UUID()
     private let reloadIDLock = NSLock()
@@ -947,6 +977,39 @@ class WallpaperViewModel: ObservableObject {
         pauseOnAppFocus = defaults.bool(forKey: UserDefaultsKeys.pauseOnAppFocus)
         volume = Double(defaults.float(forKey: UserDefaultsKeys.volumePercentage))
         vinttageBar = defaults.bool(forKey: UserDefaultsKeys.vignetteBar)
+        lockScreenVideoEnabled = defaults.bool(forKey: UserDefaultsKeys.lockScreenVideo)
+    }
+
+    func setLockScreenVideo(_ enabled: Bool) {
+        let manager = LockScreenAerialManager.shared()
+        if enabled {
+            let videoPath = engine.currentVideoPath as String? ?? ""
+            if manager.isSystemSlotInstalled {
+                manager.updateUserSymlink(videoPath)
+                defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
+                lockScreenVideoEnabled = true
+                lockScreenVideoError = nil
+            } else {
+                manager.performPrivilegedSetup(withVideoPath: videoPath) { [weak self] error in
+                    DispatchQueue.main.async {
+                        guard let self else { return }
+                        if let error {
+                            self.lockScreenVideoError = error.localizedDescription
+                            self.lockScreenVideoEnabled = false
+                        } else {
+                            self.defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
+                            self.lockScreenVideoEnabled = true
+                            self.lockScreenVideoError = nil
+                        }
+                    }
+                }
+            }
+        } else {
+            _ = manager.revertIndexPlist(nil)
+            defaults.set(false, forKey: UserDefaultsKeys.lockScreenVideo)
+            lockScreenVideoEnabled = false
+            lockScreenVideoError = nil
+        }
     }
 
     func reloadContent() {

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1014,6 +1014,8 @@ class WallpaperViewModel: ObservableObject {
             var revertError: NSError?
             if !manager.revertIndexPlist(&revertError) {
                 lockScreenVideoError = revertError?.localizedDescription ?? "Failed to restore lock screen settings."
+            } else {
+                lockScreenVideoError = nil
             }
             defaults.set(false, forKey: UserDefaultsKeys.lockScreenVideo)
             lockScreenVideoEnabled = false

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -797,8 +797,8 @@ struct SettingsView: View {
                             ))
                             .toggleStyle(.switch)
                         }
-                        if let subtitle = Optional(L.lockScreenVideoSubtitle), !viewModel.lockScreenVideoEnabled {
-                            Text(subtitle)
+                        if !viewModel.lockScreenVideoEnabled {
+                            Text(L.lockScreenVideoSubtitle)
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .padding(.leading, 8)
@@ -983,9 +983,15 @@ class WallpaperViewModel: ObservableObject {
     func setLockScreenVideo(_ enabled: Bool) {
         let manager = LockScreenAerialManager.shared()
         if enabled {
-            let videoPath = engine.currentVideoPath as String? ?? ""
+            guard let rawPath = engine.currentVideoPath as String?, !rawPath.isEmpty else {
+                lockScreenVideoError = "No wallpaper is currently active."
+                lockScreenVideoEnabled = false
+                return
+            }
+            let videoPath = rawPath
             if manager.isSystemSlotInstalled {
                 manager.updateUserSymlink(videoPath)
+                _ = manager.writeIndexPlist(nil)
                 defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
                 lockScreenVideoEnabled = true
                 lockScreenVideoError = nil
@@ -1005,10 +1011,12 @@ class WallpaperViewModel: ObservableObject {
                 }
             }
         } else {
-            _ = manager.revertIndexPlist(nil)
+            var revertError: NSError?
+            if !manager.revertIndexPlist(&revertError) {
+                lockScreenVideoError = revertError?.localizedDescription ?? "Failed to restore lock screen settings."
+            }
             defaults.set(false, forKey: UserDefaultsKeys.lockScreenVideo)
             lockScreenVideoEnabled = false
-            lockScreenVideoError = nil
         }
     }
 

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -991,7 +991,6 @@ class WallpaperViewModel: ObservableObject {
             let videoPath = rawPath
             if manager.isSystemSlotInstalled {
                 manager.updateUserSymlink(videoPath)
-                _ = manager.writeIndexPlist(nil)
                 defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
                 lockScreenVideoEnabled = true
                 lockScreenVideoError = nil

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1003,7 +1003,7 @@ class WallpaperViewModel: ObservableObject {
                             self.lockScreenVideoError = error.localizedDescription
                             self.lockScreenVideoEnabled = false
                         } else {
-                            manager.writeIndexPlist(nil)
+                            LockScreenAerialManager.shared().writeIndexPlist(nil)
                             self.defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)
                             self.lockScreenVideoEnabled = true
                             self.lockScreenVideoError = nil

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -989,7 +989,7 @@ class WallpaperViewModel: ObservableObject {
                 return
             }
             let videoPath = rawPath
-            if manager.isSystemSlotInstalled {
+            if manager.isSystemSlotInstalled && manager.isEntriesJsonPatched {
                 manager.updateUserSymlink(videoPath)
                 manager.writeIndexPlist(nil)
                 defaults.set(true, forKey: UserDefaultsKeys.lockScreenVideo)

--- a/LiveWallpaper-Bridging-Header.h
+++ b/LiveWallpaper-Bridging-Header.h
@@ -21,5 +21,6 @@
 
 #import "WallpaperEngine.h"
 #import "DisplayObjc.h"
+#import "LockScreenAerialManager.h"
 
 #endif /* LiveWallpaper_Bridging_Header_h */

--- a/LiveWallpaper.xcodeproj/project.pbxproj
+++ b/LiveWallpaper.xcodeproj/project.pbxproj
@@ -18,11 +18,11 @@
 		04E055F42EEA8D6800F90A44 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055472EEA795F00F90A44 /* CoreGraphics.framework */; };
 		04E055F52EEA8D7100F90A44 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055DE2EEA8C2600F90A44 /* QuartzCore.framework */; };
 		04E055F72EEA8DDA00F90A44 /* wallpaperdaemon in CopyFiles */ = {isa = PBXBuildFile; fileRef = 04E055E82EEA8D2C00F90A44 /* wallpaperdaemon */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		04E055F82EEA8DDA00F90A44 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055432EEA795200F90A44 /* CoreMedia.framework */; };
 		04E056FF2EEAB3EE00F90A44 /* LiveWallpaperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E056672EEAB3EE00F90A44 /* LiveWallpaperApp.swift */; };
 		04E0570B2EEAB3EE00F90A44 /* WallpaperEngine.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04E056F02EEAB3EE00F90A44 /* WallpaperEngine.mm */; };
 		04E057192EEAB3EE00F90A44 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E0565F2EEAB3EE00F90A44 /* ContentView.swift */; };
 		04E0571C2EEAB3EE00F90A44 /* SaveSystem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04E0566C2EEAB3EE00F90A44 /* SaveSystem.mm */; };
-		AABBCC0300000000000000A1 /* LockScreenAerialManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */; };
 		04E057382EEAB3EE00F90A44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04E0565D2EEAB3EE00F90A44 /* Assets.xcassets */; };
 		04E057742EEAB43200F90A44 /* emitterstate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04E0574A2EEAB43200F90A44 /* emitterstate.cpp */; };
 		04E057752EEAB43200F90A44 /* nodebuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04E057562EEAB43200F90A44 /* nodebuilder.cpp */; };
@@ -57,6 +57,7 @@
 		04E057922EEAB43200F90A44 /* scanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04E057622EEAB43200F90A44 /* scanner.cpp */; };
 		04E057932EEAB43200F90A44 /* directives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04E057452EEAB43200F90A44 /* directives.cpp */; };
 		04F816E02EEBE3FB00CFB473 /* DisplayObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04F816DF2EEBE3FB00CFB473 /* DisplayObjc.mm */; };
+		AABBCC0300000000000000A1 /* LockScreenAerialManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -98,8 +99,6 @@
 		04E0566C2EEAB3EE00F90A44 /* SaveSystem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SaveSystem.mm; sourceTree = SOURCE_ROOT; };
 		04E056EF2EEAB3EE00F90A44 /* WallpaperEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WallpaperEngine.h; sourceTree = SOURCE_ROOT; };
 		04E056F02EEAB3EE00F90A44 /* WallpaperEngine.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WallpaperEngine.mm; sourceTree = SOURCE_ROOT; };
-		AABBCC0100000000000000A1 /* LockScreenAerialManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LockScreenAerialManager.h; sourceTree = SOURCE_ROOT; };
-		AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LockScreenAerialManager.mm; sourceTree = SOURCE_ROOT; };
 		04E057392EEAB43200F90A44 /* dragonbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dragonbox.h; sourceTree = "<group>"; };
 		04E0573A2EEAB43200F90A44 /* graphbuilder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = graphbuilder.cpp; sourceTree = "<group>"; };
 		04E0573B2EEAB43200F90A44 /* graphbuilderadapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = graphbuilderadapter.h; sourceTree = "<group>"; };
@@ -274,6 +273,8 @@
 		04E058962EEAB54E00F90A44 /* yaml-cpp.pc.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = "yaml-cpp.pc.in"; sourceTree = "<group>"; };
 		04F816DE2EEBE3FB00CFB473 /* DisplayObjc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayObjc.h; sourceTree = SOURCE_ROOT; };
 		04F816DF2EEBE3FB00CFB473 /* DisplayObjc.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisplayObjc.mm; sourceTree = SOURCE_ROOT; };
+		AABBCC0100000000000000A1 /* LockScreenAerialManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LockScreenAerialManager.h; sourceTree = SOURCE_ROOT; };
+		AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LockScreenAerialManager.mm; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -302,6 +303,7 @@
 				04E055F32EEA8D6500F90A44 /* IOKit.framework in Frameworks */,
 				04E055F22EEA8D5C00F90A44 /* AVFoundation.framework in Frameworks */,
 				04E055F12EEA8D5700F90A44 /* Cocoa.framework in Frameworks */,
+				04E055F82EEA8DDA00F90A44 /* CoreMedia.framework in Frameworks */,
 			);
 		};
 /* End PBXFrameworksBuildPhase section */
@@ -899,7 +901,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 44DJWYP5M6;
+				DEVELOPMENT_TEAM = BFZ4U4WXUC;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
@@ -953,7 +955,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 44DJWYP5M6;
+				DEVELOPMENT_TEAM = BFZ4U4WXUC;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;

--- a/LiveWallpaper.xcodeproj/project.pbxproj
+++ b/LiveWallpaper.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		048ABDDD2F4C1652001393B0 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 048ABDDC2F4C1652001393B0 /* AppIcon.icon */; };
-		04E055422EEA794C00F90A44 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055412EEA794C00F90A44 /* AVFoundation.framework */; };
+04E055422EEA794C00F90A44 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055412EEA794C00F90A44 /* AVFoundation.framework */; };
 		04E055442EEA795200F90A44 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055432EEA795200F90A44 /* CoreMedia.framework */; };
 		04E055462EEA795900F90A44 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055452EEA795900F90A44 /* CoreVideo.framework */; };
 		04E055482EEA795F00F90A44 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04E055472EEA795F00F90A44 /* CoreGraphics.framework */; };
@@ -80,8 +79,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		048ABDDC2F4C1652001393B0 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
-		04E0070A2EEA738C00F90A44 /* LiveWallpaper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LiveWallpaper.app; sourceTree = BUILT_PRODUCTS_DIR; };
+04E0070A2EEA738C00F90A44 /* LiveWallpaper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LiveWallpaper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		04E055412EEA794C00F90A44 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		04E055432EEA795200F90A44 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		04E055452EEA795900F90A44 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
@@ -316,7 +314,6 @@
 				04E055E92EEA8D2C00F90A44 /* wallpaperdaemon */,
 				04E054BD2EEA76F600F90A44 /* Frameworks */,
 				04E0070B2EEA738C00F90A44 /* Products */,
-				048ABDDC2F4C1652001393B0 /* AppIcon.icon */,
 			);
 			sourceTree = "<group>";
 		};
@@ -713,7 +710,6 @@
 			isa = PBXResourcesBuildPhase;
 			files = (
 				04E057382EEAB3EE00F90A44 /* Assets.xcassets in Resources */,
-				048ABDDD2F4C1652001393B0 /* AppIcon.icon in Resources */,
 			);
 		};
 /* End PBXResourcesBuildPhase section */

--- a/LiveWallpaper.xcodeproj/project.pbxproj
+++ b/LiveWallpaper.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		04E0570B2EEAB3EE00F90A44 /* WallpaperEngine.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04E056F02EEAB3EE00F90A44 /* WallpaperEngine.mm */; };
 		04E057192EEAB3EE00F90A44 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E0565F2EEAB3EE00F90A44 /* ContentView.swift */; };
 		04E0571C2EEAB3EE00F90A44 /* SaveSystem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 04E0566C2EEAB3EE00F90A44 /* SaveSystem.mm */; };
+		AABBCC0300000000000000A1 /* LockScreenAerialManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */; };
 		04E057382EEAB3EE00F90A44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04E0565D2EEAB3EE00F90A44 /* Assets.xcassets */; };
 		04E057742EEAB43200F90A44 /* emitterstate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04E0574A2EEAB43200F90A44 /* emitterstate.cpp */; };
 		04E057752EEAB43200F90A44 /* nodebuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 04E057562EEAB43200F90A44 /* nodebuilder.cpp */; };
@@ -97,6 +98,8 @@
 		04E0566C2EEAB3EE00F90A44 /* SaveSystem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SaveSystem.mm; sourceTree = SOURCE_ROOT; };
 		04E056EF2EEAB3EE00F90A44 /* WallpaperEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WallpaperEngine.h; sourceTree = SOURCE_ROOT; };
 		04E056F02EEAB3EE00F90A44 /* WallpaperEngine.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WallpaperEngine.mm; sourceTree = SOURCE_ROOT; };
+		AABBCC0100000000000000A1 /* LockScreenAerialManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LockScreenAerialManager.h; sourceTree = SOURCE_ROOT; };
+		AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LockScreenAerialManager.mm; sourceTree = SOURCE_ROOT; };
 		04E057392EEAB43200F90A44 /* dragonbox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dragonbox.h; sourceTree = "<group>"; };
 		04E0573A2EEAB43200F90A44 /* graphbuilder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = graphbuilder.cpp; sourceTree = "<group>"; };
 		04E0573B2EEAB43200F90A44 /* graphbuilderadapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = graphbuilderadapter.h; sourceTree = "<group>"; };
@@ -351,6 +354,8 @@
 				04E0566C2EEAB3EE00F90A44 /* SaveSystem.mm */,
 				04E056EF2EEAB3EE00F90A44 /* WallpaperEngine.h */,
 				04E056F02EEAB3EE00F90A44 /* WallpaperEngine.mm */,
+				AABBCC0100000000000000A1 /* LockScreenAerialManager.h */,
+				AABBCC0200000000000000A1 /* LockScreenAerialManager.mm */,
 				04F816DE2EEBE3FB00CFB473 /* DisplayObjc.h */,
 				04F816DF2EEBE3FB00CFB473 /* DisplayObjc.mm */,
 				04E057732EEAB43200F90A44 /* src */,
@@ -752,6 +757,7 @@
 				04E0570B2EEAB3EE00F90A44 /* WallpaperEngine.mm in Sources */,
 				04E057192EEAB3EE00F90A44 /* ContentView.swift in Sources */,
 				04E0571C2EEAB3EE00F90A44 /* SaveSystem.mm in Sources */,
+				AABBCC0300000000000000A1 /* LockScreenAerialManager.mm in Sources */,
 			);
 		};
 		04E055E42EEA8D2C00F90A44 /* Sources */ = {

--- a/LockScreenAerialManager.h
+++ b/LockScreenAerialManager.h
@@ -1,0 +1,35 @@
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LockScreenAerialManager : NSObject
+
++ (instancetype)shared;
+
+/// YES after privileged setup has created the system-level symlink slot.
+@property (nonatomic, readonly) BOOL isSystemSlotInstalled;
+
+/// Absolute path: ~/Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov
+@property (nonatomic, readonly) NSString *userCachePath;
+
+/// YES for .mov (always); for .mp4 only if codec is H.264 or HEVC.
+- (BOOL)isVideoCodecSupported:(NSString *)videoPath;
+
+/// Creates/replaces user-level symlink at userCachePath → videoPath. No admin required.
+- (void)updateUserSymlink:(NSString *)videoPath;
+
+/// Writes Index.plist to select livewallpaper_custom_001 as active lock screen asset.
+- (BOOL)writeIndexPlist:(NSError **)error;
+
+/// Reverts Index.plist to value saved before writeIndexPlist was first called.
+- (BOOL)revertIndexPlist:(NSError **)error;
+
+/// Admin-required: creates system slot symlink + patches entries.json via NSAppleScript.
+/// Calls updateUserSymlink: after success. Completion always fires on main thread.
+- (void)performPrivilegedSetupWithVideoPath:(NSString *)videoPath
+                                 completion:(void(^)(NSError * _Nullable error))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/LockScreenAerialManager.h
+++ b/LockScreenAerialManager.h
@@ -1,3 +1,21 @@
+/*
+ * This file is part of LiveWallpaper – LiveWallpaper App for macOS.
+ * Copyright (C) 2025 Bios thusvill
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 

--- a/LockScreenAerialManager.h
+++ b/LockScreenAerialManager.h
@@ -38,10 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateUserSymlink:(NSString *)videoPath;
 
 /// Writes Index.plist to select livewallpaper_custom_001 as active lock screen asset.
-- (BOOL)writeIndexPlist:(NSError **)error;
+/// NS_SWIFT_NOTHROW: not imported as throws; pass nil to ignore errors.
+- (BOOL)writeIndexPlist:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 /// Reverts Index.plist to value saved before writeIndexPlist was first called.
-- (BOOL)revertIndexPlist:(NSError **)error;
+/// NS_SWIFT_NOTHROW: not imported as throws; pass nil to ignore errors.
+- (BOOL)revertIndexPlist:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 /// Admin-required: creates system slot symlink + patches entries.json via NSAppleScript.
 /// Calls updateUserSymlink: after success. Completion always fires on main thread.

--- a/LockScreenAerialManager.h
+++ b/LockScreenAerialManager.h
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// YES after privileged setup has created the system-level symlink slot.
 @property (nonatomic, readonly) BOOL isSystemSlotInstalled;
 
+/// YES if entries.json already contains the custom asset UUID (readable without admin).
+@property (nonatomic, readonly) BOOL isEntriesJsonPatched;
+
 /// Absolute path: ~/Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov
 @property (nonatomic, readonly) NSString *userCachePath;
 

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -181,7 +181,66 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
     return [out writeToFile:path options:NSDataWritingAtomic error:outError];
 }
 
-// performPrivilegedSetupWithVideoPath:completion: — implemented in Task 2
-// kEntriesJSON = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json"
+- (void)performPrivilegedSetupWithVideoPath:(NSString *)videoPath
+                                 completion:(void(^)(NSError * _Nullable))completion {
+    NSString *home      = NSHomeDirectory();
+    NSString *cacheDir  = [home stringByAppendingPathComponent:
+                            @"Library/Caches/com.thusvill.LiveWallpaper/lockscreen"];
+    NSString *cachePath = [cacheDir stringByAppendingPathComponent:@"current.mov"];
+    NSString *sysDir    = @"/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS";
+    NSString *sysSlot   = [sysDir stringByAppendingPathComponent:@"lw_slot.mov"];
+    NSString *entries   = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json";
+
+    // Bash + Python3 script: creates cache dir, system dir, system slot symlink,
+    // and patches entries.json idempotently (checks shotID before appending).
+    NSString *bash = [NSString stringWithFormat:
+        @"#!/bin/bash\n"
+         "set -e\n"
+         "mkdir -p '%@'\n"
+         "mkdir -p '%@'\n"
+         "ln -sf '%@' '%@'\n"
+         "python3 << 'PYEOF'\n"
+         "import json, sys\n"
+         "path = '%@'\n"
+         "try:\n"
+         "    with open(path, 'r') as f: data = json.load(f)\n"
+         "except Exception: data = []\n"
+         "if not isinstance(data, list): data = [data]\n"
+         "if any(e.get('shotID') == 'livewallpaper_custom_001' for e in data): sys.exit(0)\n"
+         "sample = data[0] if data else {}\n"
+         "url_key = next((k for k in sample if '4K' in k and 'SDR' in k), 'url-4K-SDR-240FPS')\n"
+         "data.append({'shotID': 'livewallpaper_custom_001', 'localizedNameKey': 'LiveWallpaper Custom', url_key: '4KSDR240FPS/lw_slot.mov', 'previewImage': 'snapshots/lw_slot_preview.png'})\n"
+         "with open(path, 'w') as f: json.dump(data, f, indent=2)\n"
+         "PYEOF\n",
+        cacheDir, sysDir, cachePath, sysSlot, entries];
+
+    NSString *scriptPath = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:@"lw_lockscreen_setup.sh"];
+    NSError *writeErr;
+    [bash writeToFile:scriptPath atomically:YES encoding:NSUTF8StringEncoding error:&writeErr];
+    if (writeErr) { completion(writeErr); return; }
+
+    // NSAppleScript must run on main thread; dispatch so the caller doesn't block the UI.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *src = [NSString stringWithFormat:
+            @"do shell script \"bash '%@'\" with administrator privileges", scriptPath];
+        NSAppleScript *as = [[NSAppleScript alloc] initWithSource:src];
+        NSDictionary *errDict;
+        [as executeAndReturnError:&errDict];
+        [[NSFileManager defaultManager] removeItemAtPath:scriptPath error:nil];
+
+        if (errDict) {
+            NSInteger code = [errDict[NSAppleScriptErrorNumber] integerValue];
+            NSString *msg  = errDict[NSAppleScriptErrorMessage] ?: @"Privileged setup failed";
+            NSError *err   = [NSError errorWithDomain:@"LockScreenAerialManager"
+                code:code userInfo:@{NSLocalizedDescriptionKey: msg}];
+            completion(err);
+            return;
+        }
+
+        if (videoPath.length > 0) [self updateUserSymlink:videoPath];
+        completion(nil);
+    });
+}
 
 @end

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -1,8 +1,25 @@
+/*
+ * This file is part of LiveWallpaper – LiveWallpaper App for macOS.
+ * Copyright (C) 2025 Bios thusvill
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #import "LockScreenAerialManager.h"
 #import <CoreMedia/CoreMedia.h>
 
 static NSString * const kSystemSlot   = @"/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS/lw_slot.mov";
-static NSString * const kEntriesJSON  = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json";
 static NSString * const kCacheSubpath = @"Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov";
 static NSString * const kIndexPlist   = @"Library/Application Support/com.apple.wallpaper/Store/Index.plist";
 static NSString * const kShotID       = @"livewallpaper_custom_001";
@@ -49,7 +66,10 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
     NSString *dir  = [link stringByDeletingLastPathComponent];
     [fm createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
     [fm removeItemAtPath:link error:nil];
-    [fm createSymbolicLinkAtPath:link withDestinationPath:videoPath error:nil];
+    NSError *linkErr;
+    if (![fm createSymbolicLinkAtPath:link withDestinationPath:videoPath error:&linkErr]) {
+        NSLog(@"[LockScreen] createSymbolicLink failed: %@", linkErr);
+    }
 }
 
 - (BOOL)writeIndexPlist:(NSError **)outError {
@@ -72,8 +92,9 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
                        error:&readErr] mutableCopy];
     if (!plist) { if (outError) *outError = readErr; return NO; }
 
-    // Useful for debugging structure on target machine
+#ifdef DEBUG
     NSLog(@"[LockScreen] Index.plist top-level keys: %@", plist.allKeys);
+#endif
 
     // Key path from research — verify with:
     // plutil -p ~/Library/Application\ Support/com.apple.wallpaper/Store/Index.plist
@@ -140,14 +161,16 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
 
     id previous = [NSPropertyListSerialization
         propertyListWithData:saved options:NSPropertyListImmutable format:nil error:nil];
+    if (!previous) return YES;
 
     NSMutableDictionary *allSpaces = [plist[@"AllSpacesAndDisplays"] mutableCopy];
-    NSMutableDictionary *idle      = [allSpaces[@"Idle"]             mutableCopy];
-    NSMutableDictionary *content   = [idle[@"Content"]               mutableCopy];
-    content[@"Choices"]             = previous;
-    idle[@"Content"]                = content;
-    allSpaces[@"Idle"]              = idle;
-    plist[@"AllSpacesAndDisplays"]  = allSpaces;
+    if (!allSpaces || !allSpaces[@"Idle"]) return YES;
+    NSMutableDictionary *idle    = [allSpaces[@"Idle"] mutableCopy];
+    NSMutableDictionary *content = [idle[@"Content"]   mutableCopy] ?: [NSMutableDictionary dictionary];
+    content[@"Choices"]           = previous;
+    idle[@"Content"]              = content;
+    allSpaces[@"Idle"]            = idle;
+    plist[@"AllSpacesAndDisplays"] = allSpaces;
 
     NSData *out = [NSPropertyListSerialization
         dataWithPropertyList:plist
@@ -159,5 +182,6 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
 }
 
 // performPrivilegedSetupWithVideoPath:completion: — implemented in Task 2
+// kEntriesJSON = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json"
 
 @end

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -46,6 +46,19 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
     return [NSHomeDirectory() stringByAppendingPathComponent:kCacheSubpath];
 }
 
+- (BOOL)isEntriesJsonPatched {
+    NSData *data = [NSData dataWithContentsOfFile:kEntriesJSON];
+    if (!data) return NO;
+    NSArray *root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    if (![root isKindOfClass:[NSArray class]] || root.count == 0) return NO;
+    NSArray *assets = root[0][@"assets"];
+    if (![assets isKindOfClass:[NSArray class]]) return NO;
+    for (NSDictionary *asset in assets) {
+        if ([asset[@"id"] isEqualToString:kCustomAssetID]) return YES;
+    }
+    return NO;
+}
+
 - (BOOL)isVideoCodecSupported:(NSString *)videoPath {
     if ([videoPath.pathExtension.lowercaseString isEqualToString:@"mov"]) return YES;
     NSURL *url = [NSURL fileURLWithPath:videoPath];
@@ -144,7 +157,12 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
                      options:0
                        error:outError];
     if (!out) return NO;
-    return [out writeToFile:path options:NSDataWritingAtomic error:outError];
+    BOOL ok = [out writeToFile:path options:NSDataWritingAtomic error:outError];
+    if (ok) {
+        // WallpaperAgent must reload to apply Index.plist changes; it runs as current user.
+        [NSTask launchedTaskWithLaunchPath:@"/usr/bin/killall" arguments:@[@"WallpaperAgent"]];
+    }
+    return ok;
 }
 
 - (BOOL)revertIndexPlist:(NSError **)outError {
@@ -182,7 +200,12 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
                      options:0
                        error:outError];
     if (!out) return NO;
-    return [out writeToFile:path options:NSDataWritingAtomic error:outError];
+    BOOL ok = [out writeToFile:path options:NSDataWritingAtomic error:outError];
+    if (ok) {
+        // WallpaperAgent must reload to apply Index.plist changes; it runs as current user.
+        [NSTask launchedTaskWithLaunchPath:@"/usr/bin/killall" arguments:@[@"WallpaperAgent"]];
+    }
+    return ok;
 }
 
 - (void)performPrivilegedSetupWithVideoPath:(NSString *)videoPath

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -23,7 +23,8 @@ static NSString * const kSystemSlot   = @"/Library/Application Support/com.apple
 static NSString * const kEntriesJSON  = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json";
 static NSString * const kCacheSubpath = @"Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov";
 static NSString * const kIndexPlist   = @"Library/Application Support/com.apple.wallpaper/Store/Index.plist";
-static NSString * const kShotID       = @"livewallpaper_custom_001";
+static NSString * const kShotID        = @"livewallpaper_custom_001";
+static NSString * const kCustomAssetID = @"AABBCCDD-EEFF-0011-2233-445566778899";
 static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
 
 @implementation LockScreenAerialManager
@@ -119,18 +120,20 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
         if (saved) [[NSUserDefaults standardUserDefaults] setObject:saved forKey:kSavedChoicesKey];
     }
 
-    // Aerial-style choice dictionary — adjust if plutil shows a different structure
+    // Configuration: binary plist {'assetID': kCustomAssetID} — matches macOS 26 aerial format.
+    NSError *cfgErr;
+    NSData *configData = [NSPropertyListSerialization
+        dataWithPropertyList:@{@"assetID": kCustomAssetID}
+                      format:NSPropertyListBinaryFormat_v1_0
+                     options:0
+                       error:&cfgErr];
+    if (!configData) { if (outError) *outError = cfgErr; return NO; }
+
     content[@"Choices"] = @[@{
-        @"BackgroundColor": @{},
-        @"Provider": @{
-            @"Library": @{
-                @"Assets": @[@{
-                    @"Value": @{@"Identifier": kShotID}
-                }]
-            }
-        }
+        @"Configuration": configData,
+        @"Files": @[],
+        @"Provider": @"com.apple.wallpaper.choice.aerials"
     }];
-    content[@"UsesSingleChoice"] = @YES;
     idle[@"Content"]              = content;
     allSpaces[@"Idle"]            = idle;
     plist[@"AllSpacesAndDisplays"] = allSpaces;
@@ -203,14 +206,16 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
          "python3 << 'PYEOF'\n"
          "import json, sys\n"
          "path = '%@'\n"
+         "kID = 'AABBCCDD-EEFF-0011-2233-445566778899'\n"
          "try:\n"
          "    with open(path, 'r') as f: data = json.load(f)\n"
-         "except Exception: data = []\n"
-         "if not isinstance(data, list): data = [data]\n"
-         "if any(e.get('shotID') == 'livewallpaper_custom_001' for e in data): sys.exit(0)\n"
-         "sample = data[0] if data else {}\n"
-         "url_key = next((k for k in sample if '4K' in k and 'SDR' in k), 'url-4K-SDR-240FPS')\n"
-         "data.append({'shotID': 'livewallpaper_custom_001', 'localizedNameKey': 'LiveWallpaper Custom', url_key: '4KSDR240FPS/lw_slot.mov', 'previewImage': 'snapshots/lw_slot_preview.png'})\n"
+         "except Exception: data = [{}]\n"
+         "if not isinstance(data, list) or not data: data = [{}]\n"
+         "assets = data[0].get('assets', [])\n"
+         "if not isinstance(assets, list): assets = []\n"
+         "if any(e.get('id') == kID for e in assets): sys.exit(0)\n"
+         "assets.append({'id': kID, 'shotID': 'livewallpaper_custom_001', 'localizedNameKey': 'LiveWallpaper Custom', 'url-4K-SDR-240FPS': '4KSDR240FPS/lw_slot.mov', 'previewImage': 'snapshots/lw_slot_preview.png', 'showInTopLevel': True, 'includeInShuffle': False})\n"
+         "data[0]['assets'] = assets\n"
          "with open(path, 'w') as f: json.dump(data, f, indent=2)\n"
          "PYEOF\n"
          "killall idleassetsd 2>/dev/null || true\n",

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -1,0 +1,163 @@
+#import "LockScreenAerialManager.h"
+#import <CoreMedia/CoreMedia.h>
+
+static NSString * const kSystemSlot   = @"/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS/lw_slot.mov";
+static NSString * const kEntriesJSON  = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json";
+static NSString * const kCacheSubpath = @"Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov";
+static NSString * const kIndexPlist   = @"Library/Application Support/com.apple.wallpaper/Store/Index.plist";
+static NSString * const kShotID       = @"livewallpaper_custom_001";
+static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
+
+@implementation LockScreenAerialManager
+
++ (instancetype)shared {
+    static LockScreenAerialManager *instance;
+    static dispatch_once_t token;
+    dispatch_once(&token, ^{ instance = [[self alloc] init]; });
+    return instance;
+}
+
+- (BOOL)isSystemSlotInstalled {
+    NSDictionary *attrs = [[NSFileManager defaultManager]
+        attributesOfItemAtPath:kSystemSlot error:nil];
+    return [attrs[NSFileType] isEqualToString:NSFileTypeSymbolicLink];
+}
+
+- (NSString *)userCachePath {
+    return [NSHomeDirectory() stringByAppendingPathComponent:kCacheSubpath];
+}
+
+- (BOOL)isVideoCodecSupported:(NSString *)videoPath {
+    if ([videoPath.pathExtension.lowercaseString isEqualToString:@"mov"]) return YES;
+    NSURL *url = [NSURL fileURLWithPath:videoPath];
+    AVURLAsset *asset = [AVURLAsset assetWithURL:url];
+    for (AVAssetTrack *track in [asset tracksWithMediaType:AVMediaTypeVideo]) {
+        for (id desc in track.formatDescriptions) {
+            CMVideoFormatDescriptionRef fmt = (__bridge CMVideoFormatDescriptionRef)desc;
+            CMVideoCodecType codec = CMVideoFormatDescriptionGetCodecType(fmt);
+            if (codec == kCMVideoCodecType_H264 || codec == kCMVideoCodecType_HEVC) {
+                return YES;
+            }
+        }
+    }
+    return NO;
+}
+
+- (void)updateUserSymlink:(NSString *)videoPath {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *link = self.userCachePath;
+    NSString *dir  = [link stringByDeletingLastPathComponent];
+    [fm createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    [fm removeItemAtPath:link error:nil];
+    [fm createSymbolicLinkAtPath:link withDestinationPath:videoPath error:nil];
+}
+
+- (BOOL)writeIndexPlist:(NSError **)outError {
+    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:kIndexPlist];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    if (!data) {
+        if (outError) *outError = [NSError errorWithDomain:@"LockScreenAerialManager"
+            code:1001
+            userInfo:@{NSLocalizedDescriptionKey:
+                @"Index.plist not found — verify path with:\n"
+                 "plutil -p ~/Library/Application\\ Support/com.apple.wallpaper/Store/Index.plist"}];
+        return NO;
+    }
+
+    NSError *readErr;
+    NSMutableDictionary *plist = [[NSPropertyListSerialization
+        propertyListWithData:data
+                     options:NSPropertyListMutableContainersAndLeaves
+                      format:nil
+                       error:&readErr] mutableCopy];
+    if (!plist) { if (outError) *outError = readErr; return NO; }
+
+    // Useful for debugging structure on target machine
+    NSLog(@"[LockScreen] Index.plist top-level keys: %@", plist.allKeys);
+
+    // Key path from research — verify with:
+    // plutil -p ~/Library/Application\ Support/com.apple.wallpaper/Store/Index.plist
+    NSMutableDictionary *allSpaces = [plist[@"AllSpacesAndDisplays"] mutableCopy];
+    if (!allSpaces) {
+        if (outError) *outError = [NSError errorWithDomain:@"LockScreenAerialManager"
+            code:1002
+            userInfo:@{NSLocalizedDescriptionKey:
+                @"AllSpacesAndDisplays key missing — adjust writeIndexPlist: key path to match actual plist structure"}];
+        return NO;
+    }
+
+    NSMutableDictionary *idle    = [allSpaces[@"Idle"]   mutableCopy] ?: [NSMutableDictionary dictionary];
+    NSMutableDictionary *content = [idle[@"Content"]     mutableCopy] ?: [NSMutableDictionary dictionary];
+
+    // Save current Choices for revert (serialise as XML plist for reliable round-trip)
+    id existing = content[@"Choices"];
+    if (existing) {
+        NSData *saved = [NSPropertyListSerialization
+            dataWithPropertyList:existing format:NSPropertyListXMLFormat_v1_0 options:0 error:nil];
+        if (saved) [[NSUserDefaults standardUserDefaults] setObject:saved forKey:kSavedChoicesKey];
+    }
+
+    // Aerial-style choice dictionary — adjust if plutil shows a different structure
+    content[@"Choices"] = @[@{
+        @"BackgroundColor": @{},
+        @"Provider": @{
+            @"Library": @{
+                @"Assets": @[@{
+                    @"Value": @{@"Identifier": kShotID}
+                }]
+            }
+        }
+    }];
+    content[@"UsesSingleChoice"] = @YES;
+    idle[@"Content"]              = content;
+    allSpaces[@"Idle"]            = idle;
+    plist[@"AllSpacesAndDisplays"] = allSpaces;
+
+    NSData *out = [NSPropertyListSerialization
+        dataWithPropertyList:plist
+                      format:NSPropertyListBinaryFormat_v1_0
+                     options:0
+                       error:outError];
+    if (!out) return NO;
+    return [out writeToFile:path options:NSDataWritingAtomic error:outError];
+}
+
+- (BOOL)revertIndexPlist:(NSError **)outError {
+    NSData *saved = [[NSUserDefaults standardUserDefaults] dataForKey:kSavedChoicesKey];
+    if (!saved) return YES;  // nothing to revert
+
+    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:kIndexPlist];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    if (!data) return YES;
+
+    NSError *readErr;
+    NSMutableDictionary *plist = [[NSPropertyListSerialization
+        propertyListWithData:data
+                     options:NSPropertyListMutableContainersAndLeaves
+                      format:nil
+                       error:&readErr] mutableCopy];
+    if (!plist) { if (outError) *outError = readErr; return NO; }
+
+    id previous = [NSPropertyListSerialization
+        propertyListWithData:saved options:NSPropertyListImmutable format:nil error:nil];
+
+    NSMutableDictionary *allSpaces = [plist[@"AllSpacesAndDisplays"] mutableCopy];
+    NSMutableDictionary *idle      = [allSpaces[@"Idle"]             mutableCopy];
+    NSMutableDictionary *content   = [idle[@"Content"]               mutableCopy];
+    content[@"Choices"]             = previous;
+    idle[@"Content"]                = content;
+    allSpaces[@"Idle"]              = idle;
+    plist[@"AllSpacesAndDisplays"]  = allSpaces;
+
+    NSData *out = [NSPropertyListSerialization
+        dataWithPropertyList:plist
+                      format:NSPropertyListBinaryFormat_v1_0
+                     options:0
+                       error:outError];
+    if (!out) return NO;
+    return [out writeToFile:path options:NSDataWritingAtomic error:outError];
+}
+
+// performPrivilegedSetupWithVideoPath:completion: — implemented in Task 2
+
+@end

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -189,13 +189,15 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
     NSString *sysSlot   = kSystemSlot;
     NSString *sysDir    = [sysSlot stringByDeletingLastPathComponent];
 
-    // Bash + Python3 script: creates cache dir, system dir, system slot symlink,
-    // and patches entries.json idempotently (checks shotID before appending).
+    // Create user-level cache dir without admin so symlink writes succeed later.
+    [[NSFileManager defaultManager] createDirectoryAtPath:cacheDir
+                                withIntermediateDirectories:YES attributes:nil error:nil];
+
+    // Privileged script: system dir + system slot symlink + entries.json patch.
     NSString *bash = [NSString stringWithFormat:
         @"#!/bin/bash\n"
          "set -e\n"
          "command -v python3 >/dev/null 2>&1 || { echo 'python3 not found' >&2; exit 1; }\n"
-         "mkdir -p '%@'\n"
          "mkdir -p '%@'\n"
          "ln -sf '%@' '%@'\n"
          "python3 << 'PYEOF'\n"
@@ -212,7 +214,7 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
          "with open(path, 'w') as f: json.dump(data, f, indent=2)\n"
          "PYEOF\n"
          "killall idleassetsd 2>/dev/null || true\n",
-        cacheDir, sysDir, cachePath, sysSlot, kEntriesJSON];
+        sysDir, cachePath, sysSlot, kEntriesJSON];
 
     NSString *scriptPath = @"/tmp/lw_lockscreen_setup.sh";
     NSError *writeErr;

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -20,6 +20,7 @@
 #import <CoreMedia/CoreMedia.h>
 
 static NSString * const kSystemSlot   = @"/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS/lw_slot.mov";
+static NSString * const kEntriesJSON  = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json";
 static NSString * const kCacheSubpath = @"Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov";
 static NSString * const kIndexPlist   = @"Library/Application Support/com.apple.wallpaper/Store/Index.plist";
 static NSString * const kShotID       = @"livewallpaper_custom_001";
@@ -183,19 +184,17 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
 
 - (void)performPrivilegedSetupWithVideoPath:(NSString *)videoPath
                                  completion:(void(^)(NSError * _Nullable))completion {
-    NSString *home      = NSHomeDirectory();
-    NSString *cacheDir  = [home stringByAppendingPathComponent:
-                            @"Library/Caches/com.thusvill.LiveWallpaper/lockscreen"];
-    NSString *cachePath = [cacheDir stringByAppendingPathComponent:@"current.mov"];
-    NSString *sysDir    = @"/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS";
-    NSString *sysSlot   = [sysDir stringByAppendingPathComponent:@"lw_slot.mov"];
-    NSString *entries   = @"/Library/Application Support/com.apple.idleassetsd/Customer/entries.json";
+    NSString *cachePath = self.userCachePath;
+    NSString *cacheDir  = [cachePath stringByDeletingLastPathComponent];
+    NSString *sysSlot   = kSystemSlot;
+    NSString *sysDir    = [sysSlot stringByDeletingLastPathComponent];
 
     // Bash + Python3 script: creates cache dir, system dir, system slot symlink,
     // and patches entries.json idempotently (checks shotID before appending).
     NSString *bash = [NSString stringWithFormat:
         @"#!/bin/bash\n"
          "set -e\n"
+         "command -v python3 >/dev/null 2>&1 || { echo 'python3 not found' >&2; exit 1; }\n"
          "mkdir -p '%@'\n"
          "mkdir -p '%@'\n"
          "ln -sf '%@' '%@'\n"
@@ -212,10 +211,9 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
          "data.append({'shotID': 'livewallpaper_custom_001', 'localizedNameKey': 'LiveWallpaper Custom', url_key: '4KSDR240FPS/lw_slot.mov', 'previewImage': 'snapshots/lw_slot_preview.png'})\n"
          "with open(path, 'w') as f: json.dump(data, f, indent=2)\n"
          "PYEOF\n",
-        cacheDir, sysDir, cachePath, sysSlot, entries];
+        cacheDir, sysDir, cachePath, sysSlot, kEntriesJSON];
 
-    NSString *scriptPath = [NSTemporaryDirectory()
-        stringByAppendingPathComponent:@"lw_lockscreen_setup.sh"];
+    NSString *scriptPath = @"/tmp/lw_lockscreen_setup.sh";
     NSError *writeErr;
     [bash writeToFile:scriptPath atomically:YES encoding:NSUTF8StringEncoding error:&writeErr];
     if (writeErr) { completion(writeErr); return; }
@@ -230,7 +228,8 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
         [[NSFileManager defaultManager] removeItemAtPath:scriptPath error:nil];
 
         if (errDict) {
-            NSInteger code = [errDict[NSAppleScriptErrorNumber] integerValue];
+            NSNumber *codeNum = errDict[NSAppleScriptErrorNumber];
+            NSInteger code    = codeNum ? codeNum.integerValue : -1;
             NSString *msg  = errDict[NSAppleScriptErrorMessage] ?: @"Privileged setup failed";
             NSError *err   = [NSError errorWithDomain:@"LockScreenAerialManager"
                 code:code userInfo:@{NSLocalizedDescriptionKey: msg}];

--- a/LockScreenAerialManager.mm
+++ b/LockScreenAerialManager.mm
@@ -210,7 +210,8 @@ static NSString * const kSavedChoicesKey = @"lockscreenPreviousChoices";
          "url_key = next((k for k in sample if '4K' in k and 'SDR' in k), 'url-4K-SDR-240FPS')\n"
          "data.append({'shotID': 'livewallpaper_custom_001', 'localizedNameKey': 'LiveWallpaper Custom', url_key: '4KSDR240FPS/lw_slot.mov', 'previewImage': 'snapshots/lw_slot_preview.png'})\n"
          "with open(path, 'w') as f: json.dump(data, f, indent=2)\n"
-         "PYEOF\n",
+         "PYEOF\n"
+         "killall idleassetsd 2>/dev/null || true\n",
         cacheDir, sysDir, cachePath, sysSlot, kEntriesJSON];
 
     NSString *scriptPath = @"/tmp/lw_lockscreen_setup.sh";

--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ Click the "OpenInFinder" button and it'll open a folder, you can place wallpaper
 
 > https://github.com/user-attachments/assets/3d82e07d-b6b9-4a7d-b6de-5dd05dff3128
 
+## Lock Screen Video
+
+LiveWallpaper can play your current wallpaper video on the macOS lock screen using Apple's native Aerial system.
+
+**Requirements:**
+- Video format: `.mov` (H.264 or HEVC) or `.mp4` (H.264 or HEVC)
+- macOS 14+
+
+**Setup:**
+
+1. Select a wallpaper video in the main window
+2. Open **Settings** and enable **Lock Screen Video 🔒**
+3. The first time, a one-time administrator password prompt will appear — this installs a system slot for the lock screen asset
+4. Lock your screen to verify playback
+
+> [!NOTE]
+> The administrator prompt appears only once per machine. Subsequent wallpaper changes update without elevated privileges.
+
+> [!IMPORTANT]
+> The lock screen video follows the desktop wallpaper. Changing the active wallpaper automatically updates the lock screen when the toggle is enabled.
+
 ## Bug reports
 
 Post bugs with result of following command.
@@ -58,7 +79,7 @@ Post bugs with result of following command.
 
 > ![Application](./asset/application.png)
 
-> ## This is a static image, currently LiveWallpaper doesn't support videos on the lock screen.
+> ## Lock screen video wallpaper is now supported — enable it in Settings.
 > ![lockscreen](./asset/lockscreen.png)
 
 > ![settings](./asset/settings.png)

--- a/WallpaperEngine.mm
+++ b/WallpaperEngine.mm
@@ -17,6 +17,7 @@
  */
 
 #import "WallpaperEngine.h"
+#import "LockScreenAerialManager.h"
 #include "DisplayObjc.h"
 #include "SaveSystem.h"
 #import <CoreGraphics/CoreGraphics.h>
@@ -949,6 +950,9 @@ static NSString *folderPath = nil;
   }
 
   self.currentVideoPath = videoPath;
+  if ([NSUserDefaults.standardUserDefaults boolForKey:@"lockscreenVideoEnabled"]) {
+    [LockScreenAerialManager.shared updateUserSymlink:videoPath];
+  }
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setObject:videoPath forKey:@"LastWallpaperPath"];
   [defaults synchronize];

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -57,3 +57,7 @@
 "language_changed_title" = "Language Changed";
 "language_changed_message" = "Please restart the app for the language change to take effect.";
 "ok" = "OK";
+
+// MARK: - Lock Screen
+"lock_screen_video" = "Lock Screen Video 🔒";
+"lock_screen_video_subtitle" = "Requires one-time administrator access";

--- a/wallpaperdaemon/daemon.mm
+++ b/wallpaperdaemon/daemon.mm
@@ -386,11 +386,13 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
       CFAbsoluteTime elapsed = CFAbsoluteTimeGetCurrent() - _lockSystemTime;
       double lockSecs        = CMTimeGetSeconds(_lockVideoTime);
       double durSecs         = CMTimeGetSeconds(_videoDuration);
-      double resumeSecs      = fmod(lockSecs + elapsed, durSecs);
-      CMTime resumeTime      = CMTimeMakeWithSeconds(resumeSecs, 600);
-      [_players.firstObject seekToTime:resumeTime
-                     toleranceBefore:kCMTimeZero
-                      toleranceAfter:kCMTimeZero];
+      if (durSecs > 0.0) {
+        double resumeSecs = fmod(lockSecs + elapsed, durSecs);
+        CMTime resumeTime = CMTimeMakeWithSeconds(resumeSecs, 600);
+        [_players.firstObject seekToTime:resumeTime
+                       toleranceBefore:kCMTimeZero
+                        toleranceAfter:kCMTimeZero];
+      }
     }
 
     // Set windows to invisible so the fade-in hides the WVE->daemon seam.

--- a/wallpaperdaemon/daemon.mm
+++ b/wallpaperdaemon/daemon.mm
@@ -374,6 +374,7 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
   for (AVQueuePlayer *player in _players) {
     [player pause];
   }
+  self.playbackPaused = YES;
 }
 
 - (void)screenUnlocked:(NSNotification *)note {

--- a/wallpaperdaemon/daemon.mm
+++ b/wallpaperdaemon/daemon.mm
@@ -366,7 +366,8 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
         self.wasPlayingBeforeSleep ? @"playing" : @"paused");
   self.screen_locked = true;
 
-  _lockVideoTime  = _players.firstObject.currentItem.currentTime;
+  AVPlayerItem *item = _players.firstObject.currentItem;
+  _lockVideoTime  = item ? item.currentTime : kCMTimeZero;
   _lockSystemTime = CFAbsoluteTimeGetCurrent();
   CMTime d = _asset.duration;
   _videoDuration = (CMTIME_IS_VALID(d) && !CMTIME_IS_INDEFINITE(d)) ? d : kCMTimeInvalid;
@@ -382,7 +383,27 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
   self.screen_locked = false;
 
   if (self.wasPlayingBeforeSleep) {
+    // Set windows invisible first so the fade-in hides the WVE->daemon seam.
+    // Do NOT kill WallpaperVideoExtension — idleassetsd owns its lifecycle;
+    // killing it breaks the next lock cycle (black lock screen on re-lock).
+    for (NSWindow *window in _windows) {
+      window.alphaValue = 0.0;
+    }
+
+    // Block that resumes playback and fades windows back in.
+    void (^resumeAndFade)(void) = ^{
+      NSLog(@"[Daemon] Resuming playback after screen unlock");
+      [self resumeAllPlayers];
+      [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+        ctx.duration = 0.4;
+        for (NSWindow *window in self->_windows) {
+          window.animator.alphaValue = 1.0;
+        }
+      }];
+    };
+
     // Seek to elapsed position so desktop resumes where the lock screen left off.
+    BOOL seekDispatched = NO;
     if (CMTIME_IS_VALID(_videoDuration) && !CMTIME_IS_INDEFINITE(_videoDuration)) {
       CFAbsoluteTime elapsed = CFAbsoluteTimeGetCurrent() - _lockSystemTime;
       double lockSecs        = CMTimeGetSeconds(_lockVideoTime);
@@ -390,28 +411,18 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
       if (durSecs > 0.0) {
         double resumeSecs = fmod(lockSecs + elapsed, durSecs);
         CMTime resumeTime = CMTimeMakeWithSeconds(resumeSecs, 600);
+        seekDispatched = YES;
         [_players.firstObject seekToTime:resumeTime
                        toleranceBefore:kCMTimeZero
-                        toleranceAfter:kCMTimeZero];
+                        toleranceAfter:kCMTimeZero
+                      completionHandler:^(BOOL finished) {
+          dispatch_async(dispatch_get_main_queue(), resumeAndFade);
+        }];
       }
     }
-
-    // Set windows to invisible so the fade-in hides the WVE->daemon seam.
-    // Do NOT kill WallpaperVideoExtension — idleassetsd owns its lifecycle;
-    // killing it breaks the next lock cycle (black lock screen on re-lock).
-    for (NSWindow *window in _windows) {
-      window.alphaValue = 0.0;
+    if (!seekDispatched) {
+      resumeAndFade();
     }
-
-    NSLog(@"[Daemon] Resuming playback after screen unlock");
-    [self resumeAllPlayers];
-
-    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
-      ctx.duration = 0.4;
-      for (NSWindow *window in self->_windows) {
-        window.animator.alphaValue = 1.0;
-      }
-    }];
   }
 
   dispatch_after(

--- a/wallpaperdaemon/daemon.mm
+++ b/wallpaperdaemon/daemon.mm
@@ -77,7 +77,11 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
   });
 }
 
-@implementation VideoWallpaperDaemon
+@implementation VideoWallpaperDaemon {
+    CMTime         _lockVideoTime;   // player position at lock time
+    CFAbsoluteTime _lockSystemTime;  // wall-clock at lock time
+    CMTime         _videoDuration;   // cached; kCMTimeInvalid if asset not loaded
+}
 
 - (instancetype)initWithVideo:(NSString *)videoPath
                   frameOutput:(NSString *)framePath
@@ -361,6 +365,12 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
   NSLog(@"[Daemon] Screen locked - saving playback state: %@",
         self.wasPlayingBeforeSleep ? @"playing" : @"paused");
   self.screen_locked = true;
+
+  _lockVideoTime  = _players.firstObject.currentItem.currentTime;
+  _lockSystemTime = CFAbsoluteTimeGetCurrent();
+  CMTime d = _asset.duration;
+  _videoDuration = (CMTIME_IS_VALID(d) && !CMTIME_IS_INDEFINITE(d)) ? d : kCMTimeInvalid;
+
   for (AVQueuePlayer *player in _players) {
     [player pause];
   }
@@ -369,10 +379,38 @@ static void DisplayReconfigCallback(CGDirectDisplayID display,
 - (void)screenUnlocked:(NSNotification *)note {
   NSLog(@"[Daemon] Screen unlocked");
   self.screen_locked = false;
+
   if (self.wasPlayingBeforeSleep) {
+    // Seek to elapsed position so desktop resumes where the lock screen left off.
+    if (CMTIME_IS_VALID(_videoDuration) && !CMTIME_IS_INDEFINITE(_videoDuration)) {
+      CFAbsoluteTime elapsed = CFAbsoluteTimeGetCurrent() - _lockSystemTime;
+      double lockSecs        = CMTimeGetSeconds(_lockVideoTime);
+      double durSecs         = CMTimeGetSeconds(_videoDuration);
+      double resumeSecs      = fmod(lockSecs + elapsed, durSecs);
+      CMTime resumeTime      = CMTimeMakeWithSeconds(resumeSecs, 600);
+      [_players.firstObject seekToTime:resumeTime
+                     toleranceBefore:kCMTimeZero
+                      toleranceAfter:kCMTimeZero];
+    }
+
+    // Set windows to invisible so the fade-in hides the WVE->daemon seam.
+    // Do NOT kill WallpaperVideoExtension — idleassetsd owns its lifecycle;
+    // killing it breaks the next lock cycle (black lock screen on re-lock).
+    for (NSWindow *window in _windows) {
+      window.alphaValue = 0.0;
+    }
+
     NSLog(@"[Daemon] Resuming playback after screen unlock");
     [self resumeAllPlayers];
+
+    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+      ctx.duration = 0.4;
+      for (NSWindow *window in self->_windows) {
+        window.animator.alphaValue = 1.0;
+      }
+    }];
   }
+
   dispatch_after(
       dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
       dispatch_get_main_queue(), ^{


### PR DESCRIPTION
## Summary

- Adds full-motion video wallpaper support for the macOS lock screen using Apple's native Aerial system
- Injects a two-level symlink chain (`system slot → user cache → video`) so subsequent wallpaper changes require no admin access after the first setup
- Daemon saves playback position at lock time and resumes at the correct timestamp after unlock with a 0.4s fade-in (no WallpaperVideoExtension kill)
- New **Lock Screen Video 🔒** toggle in Settings with error feedback

## How it works

1. **One-time privileged setup** — on first enable, a bash+Python3 script runs via NSAppleScript with admin privileges to:
   - Create the system slot symlink at `/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS/lw_slot.mov`
   - Append `livewallpaper_custom_001` to `entries.json` (idempotent)
2. **Subsequent changes** — `updateUserSymlink:` updates `~/Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov` without any admin prompt
3. **Index.plist** — `writeIndexPlist:` sets `AllSpacesAndDisplays.Idle.Content.Choices` to select the custom asset as the active lock screen
4. **Timing sync** — `screenLocked:` snapshots `CMTime + CFAbsoluteTime`; `screenUnlocked:` seeks via `completionHandler:` then fades windows in

## Files changed

| File | Change |
|---|---|
| `LockScreenAerialManager.h` / `.mm` | New Obj-C singleton — symlink chain, entries.json, Index.plist, privileged setup |
| `LiveWallpaper-Bridging-Header.h` | Import for Swift visibility |
| `LiveWallpaper.xcodeproj/project.pbxproj` | Register new source files |
| `wallpaperdaemon/daemon.mm` | Timing snapshot at lock + seek-on-unlock + 0.4s fade-in |
| `ContentView.swift` | Lock Screen Video toggle in Settings with error/subtitle display |
| `WallpaperEngine.mm` | Hook to update user symlink on wallpaper change when toggle is on |
| `en.lproj/Localizable.strings` | New lock screen strings |
| `README.md` | Lock Screen Video section with setup steps and format requirements |

## Test plan

> ⚠️ **Unable to test locally** — no Apple ID available to install Xcode. Please verify on a Mac with Xcode installed.

- [ ] Build succeeds with no errors or warnings
- [ ] Select a `.mov` or `.mp4` wallpaper and enable **Lock Screen Video 🔒** in Settings
- [ ] Admin password prompt appears on first enable
- [ ] Verify symlinks: `ls -la "/Library/Application Support/com.apple.idleassetsd/Customer/4KSDR240FPS/lw_slot.mov"` and `ls -la ~/Library/Caches/com.thusvill.LiveWallpaper/lockscreen/current.mov`
- [ ] Lock screen plays video (⌘⌃Q to lock)
- [ ] Unlock resumes desktop video at correct timestamp with smooth fade-in
- [ ] Change wallpaper while toggle is on — lock screen updates without another admin prompt
- [ ] Disable toggle — lock screen reverts to default, no error shown
- [ ] Enable toggle with no active wallpaper — "No wallpaper is currently active." error shown
- [ ] Re-lock after disable — default macOS lock screen restored

🤖 Generated with [Claude Code](https://claude.ai/claude-code)