### PR TITLE
Scale thumbnail image resolution for sharp thumbnails

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -271,7 +271,7 @@ struct VideoGridView: View {
     let viewModel: WallpaperViewModel
     let onVideoSelect: (VideoItem) -> Void
 
-    private let columns = [GridItem(.adaptive(minimum: THUMBNAIL_WIDTH, maximum: THUMBNAIL_WIDTH), spacing: 2)]
+    private let columns = [GridItem(.adaptive(minimum: THUMBNAIL_WIDTH, maximum: THUMBNAIL_WIDTH), spacing: 6)]
 
     var body: some View {
         ScrollView {
@@ -298,7 +298,7 @@ struct VideoGridView: View {
                 .buttonStyle(.borderedProminent)
                 .frame(maxWidth: .infinity, minHeight: 200)
             } else {
-                LazyVGrid(columns: columns, spacing: 2) {
+                LazyVGrid(columns: columns, spacing: 6) {
                     ForEach(videos) { video in
                         VideoThumbnailButton(video: video) {
                             onVideoSelect(video)

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -271,7 +271,7 @@ struct VideoGridView: View {
     let viewModel: WallpaperViewModel
     let onVideoSelect: (VideoItem) -> Void
 
-    private let columns = [GridItem(.adaptive(minimum: 250, maximum: 250), spacing: 2)]
+    private let columns = [GridItem(.adaptive(minimum: THUMBNAIL_WIDTH, maximum: THUMBNAIL_WIDTH), spacing: 2)]
 
     var body: some View {
         ScrollView {
@@ -328,12 +328,12 @@ struct VideoThumbnailButton: View {
                     Image(nsImage: thumbnail)
                         .resizable()
                         .aspectRatio(16 / 9, contentMode: .fill)
-                        .frame(height: 140)
+                        .frame(height: THUMBNAIL_HEIGHT)
                         .clipped()
                 } else {
                     Rectangle()
                         .fill(Color.gray.opacity(0.3))
-                        .frame(height: 140)
+                        .frame(height: THUMBNAIL_HEIGHT)
                         .overlay {
                             VStack(spacing: 4) {
                                 ProgressView()

--- a/SharedConstants.h
+++ b/SharedConstants.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of LiveWallpaper – LiveWallpaper App for macOS.
- * Copyright (C) 2025 Bios thusvill
+ * Copyright (C) 2026 Bios thusvill
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,11 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef LiveWallpaper_Bridging_Header_h
-#define LiveWallpaper_Bridging_Header_h
+#ifndef SharedConstants_h
+#define SharedConstants_h
 
-#import "WallpaperEngine.h"
-#import "DisplayObjc.h"
-#import "SharedConstants.h"
+static const double THUMBNAIL_WIDTH = 250.0;
+static const double THUMBNAIL_HEIGHT = 140.0;
 
-#endif /* LiveWallpaper_Bridging_Header_h */
+#endif /* SharedConstants_h */

--- a/SharedConstants.h
+++ b/SharedConstants.h
@@ -19,7 +19,7 @@
 #ifndef SharedConstants_h
 #define SharedConstants_h
 
-static const double THUMBNAIL_WIDTH = 250.0;
-static const double THUMBNAIL_HEIGHT = 140.0;
+static const double THUMBNAIL_WIDTH = 300.0;
+static const double THUMBNAIL_HEIGHT = 168.0;
 
 #endif /* SharedConstants_h */

--- a/WallpaperEngine.mm
+++ b/WallpaperEngine.mm
@@ -30,7 +30,6 @@ namespace fs = std::filesystem;
 
 extern char **environ;
 
-#define THUMBNAIL_QUALITY_FACTOR 0.05f
 #define QUALITY_BADGE_FONT_SIZE 48.0f
 
 static NSString *folderPath = nil;
@@ -676,14 +675,10 @@ static NSString *folderPath = nil;
     return;
   }
 
-  // Configure render size properly
-  AVAssetTrack *track = videoTracks.firstObject;
-  CGSize naturalSize = track.naturalSize;
-  CGAffineTransform transform = track.preferredTransform;
-  CGSize renderSize = CGSizeApplyAffineTransform(naturalSize, transform);
-  generator.maximumSize =
-      CGSizeMake(fabs(renderSize.width * THUMBNAIL_QUALITY_FACTOR),
-                 fabs(renderSize.height * THUMBNAIL_QUALITY_FACTOR));
+  // Configure thumbnail size
+  NSScreen *screen = [NSScreen mainScreen];
+  CGFloat scale = screen ? screen.backingScaleFactor : 2.0;
+  generator.maximumSize = CGSizeMake(250 * scale, 140 * scale);
 
   Float64 midpoint = CMTimeGetSeconds(asset.duration) / 2.0;
   CMTime targetTime = CMTimeMakeWithSeconds(midpoint, asset.duration.timescale);
@@ -783,13 +778,7 @@ static NSString *folderPath = nil;
       return;
     }
 
-    NSDictionary *options = @{
-      (__bridge id)
-      kCGImageDestinationLossyCompressionQuality : @(THUMBNAIL_QUALITY_FACTOR)
-    };
-
-    CGImageDestinationAddImage(destination, safeImage,
-                               (__bridge CFDictionaryRef)options);
+    CGImageDestinationAddImage(destination, safeImage, NULL);
 
     if (!CGImageDestinationFinalize(destination)) {
       NSLog(@"Failed to write PNG thumbnail: %@", thumbName);

--- a/WallpaperEngine.mm
+++ b/WallpaperEngine.mm
@@ -19,6 +19,7 @@
 #import "WallpaperEngine.h"
 #include "DisplayObjc.h"
 #include "SaveSystem.h"
+#include "SharedConstants.h"
 #import <CoreGraphics/CoreGraphics.h>
 #import <IOKit/graphics/IOGraphicsLib.h>
 #include <filesystem>
@@ -678,7 +679,7 @@ static NSString *folderPath = nil;
   // Configure thumbnail size
   NSScreen *screen = [NSScreen mainScreen];
   CGFloat scale = screen ? screen.backingScaleFactor : 2.0;
-  generator.maximumSize = CGSizeMake(250 * scale, 140 * scale);
+  generator.maximumSize = CGSizeMake(THUMBNAIL_WIDTH * scale, THUMBNAIL_HEIGHT * scale);
 
   Float64 midpoint = CMTimeGetSeconds(asset.duration) / 2.0;
   CMTime targetTime = CMTimeMakeWithSeconds(midpoint, asset.duration.timescale);


### PR DESCRIPTION
## Changes
- **Scale thumbnail resolution down** to the thumbnail's dimensions. This means thumbnails look as sharp as possible, while still having a greatly reduced file size.
- Thumbnail width and height are now **defined in one place** in `SharedConstants.h`.
- Thumbnail size **increased by 20%**.
- Slightly increased **spacing** between thumbnails.

## Before:
<img width="912" height="712" alt="Thumbnails (Low Resolution)" src="https://github.com/user-attachments/assets/c6b4cb3a-c43a-4138-915a-e6faf7c64135" />

## After:
<img width="912" height="712" alt="Thumbnails (High Resolution   Bigger)" src="https://github.com/user-attachments/assets/059708a2-584b-4d9b-8436-cc20802d28ac" />