### PR TITLE
Fix: only kill wallpaperdaemon PIDs; stop trusting YAML daemon fields

### DIFF
--- a/DisplayManager.h
+++ b/DisplayManager.h
@@ -145,9 +145,29 @@ inline CGDirectDisplayID DisplayIDFromUUID(const std::string &uuidString) {
   return id;
 }
 
-inline bool KillProcessByPID(pid_t pid) {
-  if (pid <= 1) {
+#include <libproc.h>
+#include <string.h>
 
+/// Only kill PIDs that are still our wallpaperdaemon — never a recycled PID
+/// belonging to some other process (stale YAML daemon fields used to do that).
+inline bool ProcessIsWallpaperDaemon(pid_t pid) {
+  if (pid <= 1)
+    return false;
+  char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
+  int n = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
+  if (n <= 0)
+    return false;
+  const char *base = strrchr(pathbuf, '/');
+  base = base ? base + 1 : pathbuf;
+  return strcmp(base, "wallpaperdaemon") == 0;
+}
+
+inline bool KillProcessByPID(pid_t pid) {
+  if (pid <= 1)
+    return false;
+
+  if (!ProcessIsWallpaperDaemon(pid)) {
+    // Stale or foreign PID — do not SIGKILL random processes.
     return false;
   }
 
@@ -155,22 +175,22 @@ inline bool KillProcessByPID(pid_t pid) {
 
   for (int i = 0; i < 15; i++) {
     if (kill(pid, 0) != 0 && errno == ESRCH) {
-      std::printf("Process killed: %d\n", pid);
       return true;
     }
     usleep(10000);
   }
+
+  if (!ProcessIsWallpaperDaemon(pid))
+    return true;
 
   kill(pid, SIGKILL);
 
   for (int i = 0; i < 10; i++) {
     if (kill(pid, 0) != 0 && errno == ESRCH) {
-
       return true;
     }
     usleep(10000);
   }
-  printf("Process not killed");
   return false;
 }
 

--- a/SaveSystem.mm
+++ b/SaveSystem.mm
@@ -37,7 +37,8 @@ template <> struct convert<Display> {
     node["screen"] = d.screen;
     node["video"] = d.videoPath;
     node["frame"] = d.framePath;
-    node["daemon"] = (int)d.daemon;
+    // Never persist live PIDs — they go stale and must not be kill()-targets.
+    node["daemon"] = 0;
     return node;
   }
 
@@ -52,7 +53,8 @@ template <> struct convert<Display> {
 
     d.videoPath = node["video"] ? node["video"].as<std::string>() : "";
     d.framePath = node["frame"] ? node["frame"].as<std::string>() : "";
-    d.daemon = node["daemon"] ? (pid_t)node["daemon"].as<int>() : 0;
+    // Ignore any historical daemon field
+    d.daemon = 0;
 
     return true;
   }

--- a/WallpaperEngine.mm
+++ b/WallpaperEngine.mm
@@ -74,6 +74,9 @@ static NSString *folderPath = nil;
     usleep(2);
 
     displays = SaveSystem::Load();
+    for (auto &d : displays) {
+      d.daemon = 0; // never trust persisted PIDs
+    }
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
       


### PR DESCRIPTION
## Summary
- YAML stored live daemon PIDs; after reboot those PIDs can belong to other processes.
- Verify `proc_pidpath` basename is `wallpaperdaemon` before SIGTERM/SIGKILL.
- Stop persisting PIDs; zero them on load.

## Test plan
- [ ] Set wallpaper, quit, relaunch — no accidental kills
- [ ] YAML does not keep non-zero daemon fields after save
- [ ] Switching wallpapers still replaces previous daemon

Refs: https://github.com/thusvill/LiveWallpaperMacOS/issues/90