### PR TITLE
Fix wallpaper folder path normalization (percent-encoding / file URLs)

### DIFF
--- a/WallpaperEngine.h
+++ b/WallpaperEngine.h
@@ -71,6 +71,7 @@
 - (BOOL)enableAppAsLoginItem;
 
 - (NSString *)getFolderPath;
+- (NSString *)normalizedFilesystemPath:(NSString *)raw;
 - (void)checkFolderPath;
 - (void)scanDisplays;
 - (void)selectFolder:(NSString* )path;

--- a/WallpaperEngine.mm
+++ b/WallpaperEngine.mm
@@ -1068,10 +1068,43 @@ static NSString *folderPath = nil;
       CFSTR("com.live.wallpaper.terminate"), NULL, NULL, true);
 }
 
+/// Normalize user/folder paths: expand ~, strip file://, decode %20, drop trailing slash.
+- (NSString *)normalizedFilesystemPath:(NSString *)raw {
+  if (!raw.length)
+    return raw;
+
+  NSString *path = [raw
+      stringByTrimmingCharactersInSet:[NSCharacterSet
+                                          whitespaceAndNewlineCharacterSet]];
+
+  if ([path hasPrefix:@"file:"]) {
+    NSURL *url = [NSURL URLWithString:path];
+    if (url.path.length)
+      path = url.path;
+  }
+  NSString *decoded = [path stringByRemovingPercentEncoding];
+  if (decoded.length)
+    path = decoded;
+
+  path = [path stringByExpandingTildeInPath];
+
+  while (path.length > 1 && [path hasSuffix:@"/"]) {
+    path = [path substringToIndex:path.length - 1];
+  }
+  return path;
+}
+
 - (void)checkFolderPath {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   if ([defaults objectForKey:@"WallpaperFolder"]) {
-    folderPath = [defaults stringForKey:@"WallpaperFolder"];
+    folderPath =
+        [self normalizedFilesystemPath:[defaults stringForKey:@"WallpaperFolder"]];
+    if (folderPath.length &&
+        ![folderPath isEqualToString:[defaults stringForKey:@"WallpaperFolder"]]) {
+      [defaults setObject:folderPath forKey:@"WallpaperFolder"];
+      [defaults synchronize];
+      NSLog(@"Healed WallpaperFolder pref → %@", folderPath);
+    }
   } else if (!folderPath) {
     folderPath = [NSHomeDirectory() stringByAppendingPathComponent:@"LiveWall"];
     [defaults setObject:folderPath forKey:@"WallpaperFolder"];
@@ -1084,7 +1117,6 @@ static NSString *folderPath = nil;
   NSString *path = [defaults stringForKey:@"WallpaperFolder"];
 
   if (!path) {
-
     NSString *cacheDir =
         [[[NSFileManager defaultManager]
              URLsForDirectory:NSCachesDirectory
@@ -1096,6 +1128,13 @@ static NSString *folderPath = nil;
     [defaults synchronize];
   }
 
+  path = [self normalizedFilesystemPath:path];
+  if (path.length &&
+      ![path isEqualToString:[defaults stringForKey:@"WallpaperFolder"]]) {
+    [defaults setObject:path forKey:@"WallpaperFolder"];
+    [defaults synchronize];
+  }
+  folderPath = path;
   return path;
 }
 
@@ -1206,8 +1245,12 @@ static NSString *folderPath = nil;
 }
 
 - (void)selectFolder:(NSString *)path {
+  NSString *normalized = [self normalizedFilesystemPath:path];
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-  [defaults setObject:path forKey:@"WallpaperFolder"];
+  [defaults setObject:normalized forKey:@"WallpaperFolder"];
+  [defaults synchronize];
+  folderPath = normalized;
+  NSLog(@"Wallpaper folder set to: %@", normalized);
 }
 
 - (void)terminateApplication {


### PR DESCRIPTION
## Summary
- Paths like `.../Application%20Support/...` or `file://...` do not resolve on disk.
- Breaks video grid and thumbnail generation for Apple Aerial folders.
- Normalize on check/get/select; heal UserDefaults when value changes.

## Test plan
- [ ] Point at Aerials videos folder — list appears
- [ ] Percent-encoded defaults path is healed on getFolderPath
- [ ] Open-panel folder select still works

Refs: https://github.com/thusvill/LiveWallpaperMacOS/issues/90