### PR TITLE
Menu-bar agent: LSUIElement + do not force config window on launch

### DIFF
--- a/LiveWallpaper.xcodeproj/project.pbxproj
+++ b/LiveWallpaper.xcodeproj/project.pbxproj
@@ -901,6 +901,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/vendor/yaml-cpp/include";
 				INFOPLIST_KEY_CFBundleDisplayName = LiveWallpaper;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -955,6 +956,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/vendor/yaml-cpp/include";
 				INFOPLIST_KEY_CFBundleDisplayName = LiveWallpaper;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";

--- a/LiveWallpaperApp.swift
+++ b/LiveWallpaperApp.swift
@@ -76,7 +76,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.contentView = NSHostingView(rootView: ContentView())
         window.title = "LiveWallpaper"
         window.isReleasedWhenClosed = false
-        window.makeKeyAndOrderFront(nil)
+        // Menu-bar agent: do not force the config window on every launch
+        // (LaunchAgents / login items would keep reopening it).
+        window.orderOut(nil)
         
         if !hasAccessibilityAccess() {
             requestAccessibilityAccess()


### PR DESCRIPTION
## Summary
- Generated Info.plist lacked `LSUIElement` (Dock icon despite accessory policy).
- Ordering the config window front on every launch reopened it for Login Item / LaunchAgent restarts.
- Set `INFOPLIST_KEY_LSUIElement = YES`; start with `orderOut`; Show window remains in status menu.

## Test plan
- [ ] No Dock icon; status item present
- [ ] Relaunch keeps window hidden until Show window
- [ ] Show/Hide menu actions work

Refs: https://github.com/thusvill/LiveWallpaperMacOS/issues/90