### PR TITLE
Fix: reapply per-display video paths on screen reconfiguration

### DIFF
--- a/WallpaperEngine.mm
+++ b/WallpaperEngine.mm
@@ -208,20 +208,19 @@ static NSString *folderPath = nil;
 }
 
 - (void)screensDidChange:(NSNotification *)note {
-
   NSLog(@"Screens changed");
-    ScanDisplays();
-    for (Display display : displays) {
-
-      if (!display.videoPath.empty()) {
-        CGDirectDisplayID displayID = DisplayIDFromUUID(display.uuid);
-
-        [self startWallpaperWithPath:_currentVideoPath
-                          onDisplays:@[ @(displayID) ]];
-      }
-    }
-    
-    
+  ScanDisplays();
+  // Restore each display's own video path (not a single global current path).
+  for (Display display : displays) {
+    if (display.videoPath.empty())
+      continue;
+    CGDirectDisplayID displayID = DisplayIDFromUUID(display.uuid);
+    if (displayID == kCGNullDirectDisplay)
+      continue;
+    NSString *path =
+        [NSString stringWithUTF8String:display.videoPath.c_str()];
+    [self startWallpaperWithPath:path onDisplays:@[ @(displayID) ]];
+  }
 }
 
 - (NSString *)thumbnailCachePath {


### PR DESCRIPTION
## Summary
- On display reconfig, all screens restarted with `_currentVideoPath`.
- Multi-monitor setups with different videos lost assignments after sleep/reconnect.
- Restore each display's own `videoPath` from the registry.

## Test plan
- [ ] Different video per display, sleep/wake — assignments preserved
- [ ] Disconnect secondary display — no crash

Refs: https://github.com/thusvill/LiveWallpaperMacOS/issues/90