### PR TITLE
docs: use recursive xattr -cr for quarantine removal (fixes 'damaged' launch failures)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Run this: `git clone --single-branch --branch objectiveC https://github.com/thus
 > 
 > This will solve the occupation issue
 > 
-> `xattr -d com.apple.quarantine /Applications/LiveWallpaper.app` 
+> `xattr -cr /Applications/LiveWallpaper.app`
+>
+> Note: the removal must be **recursive** (`-cr`). A plain `xattr -d com.apple.quarantine /Applications/LiveWallpaper.app` only strips the attribute from the bundle root and leaves quarantined files inside the app, so macOS keeps reporting the app as damaged.
 
 Click the "OpenInFinder" button and it'll open a folder, you can place wallpapers in it.
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -31,7 +31,9 @@
 >
 > 这也会解决占用问题：
 >
-> `xattr -d com.apple.quarantine /Applications/LiveWallpaper.app`
+> `xattr -cr /Applications/LiveWallpaper.app`
+>
+> 注意：必须使用**递归**删除（`-cr`）。仅执行 `xattr -d com.apple.quarantine /Applications/LiveWallpaper.app` 只会移除应用包根目录的隔离属性，应用内部仍有被隔离的文件，macOS 会继续提示应用已损坏。
 
 点击 “OpenInFinder” 按钮会打开一个文件夹，你可以把壁纸文件放进去。
 


### PR DESCRIPTION
## Summary

Users on Tahoe following the README's Gatekeeper bypass still get **"LiveWallpaper is damaged and can't be opened"** (#63). The documented command is non-recursive:

```
xattr -d com.apple.quarantine /Applications/LiveWallpaper.app
```

It only strips the attribute from the bundle root. The shipped DMG contains files **inside** the app that carry their own `com.apple.quarantine` xattrs (`Resources/livewall.icns`, `Resources/AppIcon.icns`), so macOS keeps refusing to launch. This matches reports in the thread where removing quarantine 'didn't work' until @8Crafter's recursive `xattr -cr` variant.

This PR updates both READMEs (EN + zh-Hans) to use the recursive form and explains why.

## Additional findings (not in this PR, but worth fixing in packaging)

`codesign --verify --deep --strict` on the V2.3 DMG shows the signature seal is broken because files are copied into the bundle **after** signing:

```
a sealed resource is missing or invalid
file added: Contents/MacOS/wallpaperdeamon      <- stray typo duplicate of wallpaperdaemon
file added: Contents/Resources/livewall.icns
file added: Contents/Resources/yaml-cpp.natvis
file added: Contents/Resources/yaml-cpp.natvis.md
```

Suggested packaging fixes: re-seal as the last step before building the DMG (`codesign --force --deep -s - LiveWallpaper.app` — ad-hoc, no Apple fee), remove the stray `wallpaperdeamon` binary, and update the homebrew cask postflight from `xattr -d` to the recursive form.

Fixes the workaround path for #63